### PR TITLE
Refactor:[로그인 인증] 기존 쿠키인증에서 토큰전달 방식으로 변경(iOS Safari 이슈)

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -98,15 +98,9 @@ export class AuthService {
       .setExpirationTime('2h')
       .sign(new TextEncoder().encode(JWT_SECRET));
 
-    response.cookie('token', token, {
-      httpOnly: true, // XSS 공격 방지
-      secure: process.env.NODE_ENV === 'production', // HTTPS 환경에서만 쿠키 전송 (배포 환경에서는 true)
-      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'strict', // 배포 환경에서는 None, 로컬에서는 Strict
-      maxAge: 2 * 60 * 60 * 1000, // 2시간 후 만료
-    });
-
     response.json({
       data: {
+        token, // token 값을 전달 (25.03.21 iOS Safari 이슈로 쿠키 방식에서 수정)
         id: findUser.id,
         email: findUser.email,
         image_url: findUser.image_url,

--- a/src/middleware/jwt.middleware.ts
+++ b/src/middleware/jwt.middleware.ts
@@ -9,11 +9,15 @@ import * as jose from 'jose';
 @Injectable()
 export class JwtMiddleware implements NestMiddleware {
   async use(req: Request, res: Response, next: NextFunction) {
-    // 클라이언트 token 쿠키
-    const jwt = req.cookies.token;
+    // 클라이언트 token
+    const authorizationHeader = req.headers['authorization'] as string;
+
+    const jwt = authorizationHeader?.startsWith('Bearer ')
+      ? authorizationHeader.split(' ')[1]
+      : null;
 
     if (!jwt) {
-      throw new UnauthorizedException('쿠키가 존재하지 않습니다.');
+      throw new UnauthorizedException('토큰이 존재하지 않습니다.');
     }
 
     const JWT_SECRET = process.env.JWT_SECRET || '';
@@ -28,7 +32,7 @@ export class JwtMiddleware implements NestMiddleware {
       next();
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException('인증되지 않는 쿠키입니다.');
+      throw new UnauthorizedException('인증되지 않는 토큰입니다.');
     }
   }
 }


### PR DESCRIPTION
- iOS Safari 이슈 : 쿠키가 저장안되는 현상 (크로스 사이트 이슈)
- 해결 : 인증방법을 쿠키인증에서 -> 토큰 전달 방식으로 변경