### PR TITLE
Chores:[배포 에러] ReferenceError: crypto is not defined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,12 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import { GlobalExceptionFilter } from 'src/common/filters/global-exception.filter';
+import * as crypto from 'crypto';
+
+if (!globalThis.crypto) {
+  //@ts-expect-error: globalThis.crypto is not typed in Node.js by default
+  globalThis.crypto = crypto;
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
#### 배포 에러 코드 : 

ReferenceError: crypto is not defined
    at SchedulerOrchestrator.addCron (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/scheduler.orchestrator.js:90:38)
    at ScheduleExplorer.lookupSchedulers (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/schedule.explorer.js:67:51)
    at processMethod (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/schedule.explorer.js:45:24)
    at Array.forEach (<anonymous>)
    at /home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/schedule.explorer.js:54:18
    at Array.forEach (<anonymous>)
    at ScheduleExplorer.explore (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/schedule.explorer.js:39:26)
    at ScheduleExplorer.onModuleInit (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/schedule/dist/schedule.explorer.js:32:14)
    at MapIterator.iteratee (/home/ubuntu/joseph/joseph-api/node_modules/@nestjs/core/hooks/on-module-init.hook.js:22:43)
    at MapIterator.next (/home/ubuntu/joseph/joseph-api/node_modules/iterare/src/map.ts:9:39)

Node.js v18.20.7
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

설치했던 NestJS Schedule 라이브러리가 crypto를 전역으로 가정하였는데
global.crypto가 명시적으로 정의되어 있지 않아서 생긴 에러

#### 수정 : 

globalThis.crypto에 바인딩해서 모든 곳에서 접근 가능하도록 수정
