### PR TITLE
Fix:[unsplash api] api 호출 데이터 없을 시 예외처리 추가 + gpt 요청 content 수정

### DIFF
--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -43,7 +43,7 @@ export class GptService {
           messages: [
             {
               role: 'user',
-              content: `${randomUser.character}이 작성할 법한 인스타그램 게시글을 200자 이내로 작성해줘. message에는 #을 제외한 내용만 적고, keyword에는 키워드를 넣어줘. 예시: {"message": "...", "keywords": ["sunset", "ocean"]} 반드시 예시와 같이 JSON형태로 응답해줘.`,
+              content: `${randomUser.character}이 작성할 법한 인스타그램 게시글을 200자 이내로 작성해줘. message에는 #을 제외한 내용만 적고, keyword에는 이미지 키워드 1~2개만 넣어줘. 예시: {"message": "...", "keywords": ["sunset", "ocean"]} 반드시 예시와 같이 JSON형태로 응답해줘.`,
             },
           ],
           temperature: 0.8,
@@ -77,7 +77,11 @@ export class GptService {
 
     const imageData = await unSplashResponse.json();
 
-    const image_url = imageData?.results.at(0).urls.regular;
+    const image_url = imageData?.results.at(0)?.urls.regular;
+
+    if (!image_url) {
+      throw new Error('unsplash api 호출에 실패하였습니다.');
+    }
 
     await this.postRepository
       .createQueryBuilder('post')


### PR DESCRIPTION
Fix:[unsplash api] api 호출 데이터 없을 시 예외처리 추가
- 응답값에 results 가 빈배열로 올 경우 예외처리

gpt 요청 content 수정
- 키워드가 너무 많을 경우, 필터링 데이터가 하나도 없는 경우가 있으므로 키워드 1~2개로 제한