### PR TITLE
Update:[메인] 게시물조회 api  무한스크롤로 구현 

### DIFF
--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -21,8 +21,11 @@ export class PostController {
   constructor(private readonly postService: PostService) {}
 
   @Get()
-  async getAllPosts(): Promise<ApiResponseDto<PostEntity[]>> {
-    return this.postService.getAllPosts();
+  async getAllPosts(
+    @Query('take', ParseIntPipe) take: number,
+    @Query('cursor') cursor: string,
+  ): Promise<PostEntity[]> {
+    return this.postService.getAllPosts(take, cursor);
   }
 
   @Get(':id')


### PR DESCRIPTION
1. 응답 인터페이스는 ApiResponseDto 가 아닌, 오직 배열데이터 형태로 수정
2. take, cursor Query 추가 (cursor - 이전 데이터 내 마지막 게시물의 created_at 데이터 => 커서방식)