### PR TITLE
Fix:[auth] 카카오 로그인 - image_url 프로필 이미지 미동의시 null값이므로 isOptional로 수정

### DIFF
--- a/src/auth/dto/signin-kakao.dto.ts
+++ b/src/auth/dto/signin-kakao.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
 
 export class SigninKakaoDto {
   @IsNotEmpty()
@@ -15,7 +15,7 @@ export class KakaoUserDto {
   @IsString()
   email: string;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   image_url: string;
 


### PR DESCRIPTION
Fix:[auth] 카카오 로그인 - image_url 프로필 이미지 미동의시 null값이므로 isOptional로 수정
- 동의화면에서 프로필 이미지 항목은 선택항목
- 때문에 image_url은 필수가 아니므로 isOptional