### PR TITLE
Feat:[auth] 네이버 로그인 api 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { User } from 'src/user/user.entity';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { SigninGoogleDto } from 'src/auth/dto/signin-google.dto';
 import { SigninKakaoDto, KakaoUserDto } from 'src/auth/dto/signin-kakao.dto';
+import { SigninNaverDto } from 'src/auth/dto/signin-naver.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -83,5 +84,13 @@ export class AuthController {
     @Res() response: Response,
   ): Promise<void> {
     return this.authService.completeKakaoSignup(userDto, response);
+  }
+
+  @Post('naver')
+  async signinNaver(
+    @Body() naverDto: SigninNaverDto,
+    @Res() response: Response,
+  ): Promise<void> {
+    return this.authService.signinNaver(naverDto, response);
   }
 }

--- a/src/auth/dto/signin-naver.dto.ts
+++ b/src/auth/dto/signin-naver.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SigninNaverDto {
+  @IsNotEmpty()
+  @IsString()
+  code: string;
+
+  @IsNotEmpty()
+  @IsString()
+  state: string;
+}


### PR DESCRIPTION
#### 기존 카카오, 구글 소셜로그인과 다른 점
- 클라이언트로부터 state 문자열을 받아 access token을 받기 위한 api body에 요청
(카카오, 구글에서도 활용 가능한 방법으로 확인)