### PR TITLE
Feat:[auth] 비밀번호 재인증 api 추가 / 모든 로그인 api - 응답값에 provider 필드 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  Req,
   Res,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
@@ -19,6 +20,7 @@ import { ApiBearerAuth } from '@nestjs/swagger';
 import { SigninGoogleDto } from 'src/auth/dto/signin-google.dto';
 import { SigninKakaoDto, KakaoUserDto } from 'src/auth/dto/signin-kakao.dto';
 import { SigninNaverDto } from 'src/auth/dto/signin-naver.dto';
+import { VerifyPasswordDto } from 'src/auth/dto/verify-password';
 
 @Controller('auth')
 export class AuthController {
@@ -42,6 +44,14 @@ export class AuthController {
   @Post('signout')
   async signoutUser(@Res() response: Response): Promise<void> {
     return this.authService.signoutUser(response);
+  }
+
+  @Post('verify-password')
+  async verifyPassword(
+    @Body() verfiyDto: VerifyPasswordDto,
+    @Req() req: Request,
+  ): Promise<ApiResponseDto<null>> {
+    return this.authService.verifyPassword(verfiyDto, req);
   }
 
   @ApiBearerAuth()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -28,6 +28,7 @@ export class AuthModule implements NestModule {
         { path: 'auth/signout', method: RequestMethod.POST },
         { path: 'auth/user/:id', method: RequestMethod.PUT },
         { path: 'auth/user/:id', method: RequestMethod.DELETE },
+        { path: 'auth/verify-password', method: RequestMethod.POST },
       );
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -126,6 +126,7 @@ export class AuthService {
         email: findUser.email,
         image_url: findUser.image_url,
         username: findUser.username,
+        provider: null,
       },
       result: 'success',
       message: isDeleted
@@ -334,6 +335,7 @@ export class AuthService {
         email,
         image_url,
         username,
+        provider: 'google',
       },
       result: 'success',
       message: isDeleted
@@ -435,6 +437,7 @@ export class AuthService {
           email: findUser.email,
           image_url: findUser.image_url,
           username: findUser.username,
+          provider: 'kakao',
         },
         result: 'success',
         message: isDeleted
@@ -512,6 +515,7 @@ export class AuthService {
         email,
         image_url,
         username,
+        provider: 'kakao',
       },
       result: 'success',
       message: '카카오 로그인을 성공하였습니다.',
@@ -645,6 +649,7 @@ export class AuthService {
         email,
         image_url,
         username,
+        provider: 'naver',
       },
       result: 'success',
       message: isDeleted

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
+  Req,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -20,6 +21,7 @@ import { UpdateUserDto } from 'src/auth/dto/update-user.dto';
 import { SigninGoogleDto } from 'src/auth/dto/signin-google.dto';
 import { SigninKakaoDto, KakaoUserDto } from 'src/auth/dto/signin-kakao.dto';
 import { SigninNaverDto } from 'src/auth/dto/signin-naver.dto';
+import { VerifyPasswordDto } from 'src/auth/dto/verify-password';
 
 // 개발환경 여부
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -148,6 +150,34 @@ export class AuthService {
       result: 'success',
       message: '로그아웃하였습니다.',
     });
+  }
+
+  async verifyPassword(
+    @Body() verfiyDto: VerifyPasswordDto,
+    @Req() req: Request,
+  ): Promise<ApiResponseDto<null>> {
+    /** jwt 토큰 - 로그인한 회원의 id */
+    const user_id = req['user'].id;
+
+    const findUser = await this.userRepository.findOne({
+      where: {
+        id: user_id,
+      },
+    });
+
+    /** 패스워드 일치 여부 */
+    const isMatch = await bcrypt.compare(verfiyDto.password, findUser.password);
+
+    // 불일치시 에러
+    if (!isMatch) {
+      throw new BadRequestException('비밀번호가 일치하지 않습니다.');
+    }
+
+    return {
+      data: null,
+      result: 'success',
+      message: '비밀번호 재입력 인증을 성공하였습니다.',
+    };
   }
 
   async updateUser(

--- a/src/auth/dto/verify-password.ts
+++ b/src/auth/dto/verify-password.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class VerifyPasswordDto {
+  @IsNotEmpty()
+  @IsString()
+  password: string;
+}


### PR DESCRIPTION
### [Update:[auth] 모든 로그인 api - 응답값에 provider 필드 추가](https://github.com/changmoolee/joseph-api/commit/f2a75d5f2fcff720fcbe11a2f2b37492c08a1a3a)
- 클라이언트에서 provider를 바탕으로 -> 회원의 소셜로그인 여부를 전역상태에 저장하여 판단할 계획 

### [Feat:[auth] 비밀번호 재인증 api 추가](https://github.com/changmoolee/joseph-api/commit/edd9524396eb1aec4b773b800947b150fb35d69b)
- 내정보수정 페이지 이전, 비밀번호 재인증 페이지를 추가
- 비밀번호 재인증 페이지에서 api 사용